### PR TITLE
Add `starsd` CLI template for submitting proposal

### DIFF
--- a/developers/cosmwasm-smart-contracts.md
+++ b/developers/cosmwasm-smart-contracts.md
@@ -28,3 +28,27 @@ Join [Discord](https://discord.gg/stargaze) for more information on deploying on
 {% hint style="warning" %}
 Developer Royalties cannot be combined with bounties or Community Pool funding. For example, if you receive Community Pool funding for your contract, it cannot also receive Developer Royalties.
 {% endhint %}
+
+### How do I deploy to Stargaze mainnet?
+
+Stargaze is a permissioned chain, meaning there is a governance process to adhere to. After familiarizing yourself with the [governance process](../governance/protocol-governance "mention"), here's a template to follow for submitting an on-chain proposal.
+
+To submit a governance proposal via the `starsd` CLI, you may follow the example below.
+
+{% hint style="info" %}
+If you don't have `starsd` on your machine, please follow [these instructions](../nodes-and-validators/getting-setup "mention").
+{% endhint %}
+
+```shell
+title="Smart contract you're proposing"
+desc=$(cat desc.md | jq -Rsa | tr -d '"')
+deposit="20000000000ustars"
+
+starsd tx gov submit-proposal wasm-store your_contract_binary.wasm \
+    --title "$title" \
+    --description "$desc" \
+    --deposit $deposit \
+    --run-as $CREATOR \
+    --from $PROPOSER \
+    --gas 30000000 --gas-prices 0ustars -y
+```

--- a/governance/protocol-governance.md
+++ b/governance/protocol-governance.md
@@ -17,3 +17,25 @@ On-chain proposals should follow the following process:
 4. Create an on-chain proposal with very clear, specific, and actionable items. At this point, all issues have been flushed out in the previous steps. This is considered the definitive version of a proposal and results in an on-chain action upon passing.
 
 Proposals that don’t go through these steps will get a de-facto **No With Veto** vote by Stargaze Foundation.
+
+## CLI
+
+To submit a governance proposal via the `starsd` CLI, you may follow the example below.
+
+{% hint style="info" %}
+If you don't have `starsd` on your machine, please follow [these instructions](../nodes-and-validators/getting-setup.html).
+{% endhint %}
+
+```shell
+title="Smart contract you're proposing"
+desc=$(cat desc.md | jq -Rsa | tr -d '"')
+deposit="20000000000ustars"
+
+starsd tx gov submit-proposal wasm-store your_contract_binary.wasm \
+    --title "$title" \
+    --description "$desc" \
+    --deposit $deposit \
+    --run-as $CREATOR \
+    --from $PROPOSER \
+    --gas 30000000 --gas-prices 0ustars -y
+```

--- a/governance/protocol-governance.md
+++ b/governance/protocol-governance.md
@@ -17,25 +17,3 @@ On-chain proposals should follow the following process:
 4. Create an on-chain proposal with very clear, specific, and actionable items. At this point, all issues have been flushed out in the previous steps. This is considered the definitive version of a proposal and results in an on-chain action upon passing.
 
 Proposals that don’t go through these steps will get a de-facto **No With Veto** vote by Stargaze Foundation.
-
-## CLI
-
-To submit a governance proposal via the `starsd` CLI, you may follow the example below.
-
-{% hint style="info" %}
-If you don't have `starsd` on your machine, please follow [these instructions](../nodes-and-validators/getting-setup.html).
-{% endhint %}
-
-```shell
-title="Smart contract you're proposing"
-desc=$(cat desc.md | jq -Rsa | tr -d '"')
-deposit="20000000000ustars"
-
-starsd tx gov submit-proposal wasm-store your_contract_binary.wasm \
-    --title "$title" \
-    --description "$desc" \
-    --deposit $deposit \
-    --run-as $CREATOR \
-    --from $PROPOSER \
-    --gas 30000000 --gas-prices 0ustars -y
-```


### PR DESCRIPTION
We've had great offline exchanges with Stargaze team members and wanted to help by adding a CLI command that could be useful for future folks who with to submit a smart contract to be considered for approval and storage on the Stargaze permissioned mainnet.

**Note**: I had an unusual time getting Gitbook working locally, but have links that use the pattern `[…](../path/filename_no_extension "mention")` pattern I saw elsewhere, like here:

https://github.com/public-awesome/docs/blob/158516212e43563c19478b13cada990e7957fb43/guides/stargaze-studio/create-an-nft-collection/configure-collection-and-minting-details.md?plain=1#L31