### PR TITLE
Increase gov prop bond from 20k STARS to 50k

### DIFF
--- a/developers/cosmwasm-smart-contracts.md
+++ b/developers/cosmwasm-smart-contracts.md
@@ -42,7 +42,7 @@ If you don't have `starsd` on your machine, please follow [these instructions](.
 ```shell
 title="Smart contract you're proposing"
 desc=$(cat desc.md | jq -Rsa | tr -d '"')
-deposit="20000000000ustars"
+deposit="50000000000ustars"
 
 starsd tx gov submit-proposal wasm-store your_contract_binary.wasm \
     --title "$title" \


### PR DESCRIPTION
After doing three props for CronCat recently, I heard that I didn't attach enough for the bond, which is a bit higher now.

Good ol' one-liner to pump my stats as a contributor 😆 

Thanks for the super fast help on this, Stargaze team

Shows my initial bond, as then the new bond amount:

<img width="699" alt="Screen Shot 2023-06-23 at 10 55 01 AM" src="https://github.com/public-awesome/docs/assets/1042667/a31692c6-bc66-44ac-8547-dafa3128b91c">
