### PR TITLE
Improved Readability and Minor Fixes in Documentation

### DIFF
--- a/core-apps/infinity-swap/how-it-works.md
+++ b/core-apps/infinity-swap/how-it-works.md
@@ -4,24 +4,24 @@ description: Creating Pools
 
 # How it works
 
-Each pool is created by the holder or buyer of a specific collection. There can be multiple pools of the same collection, and you may create as many pools as you want. There is a small fee that must be paid when creating a pool.
+Each pool is created by the holder or buyer of a specific collection. There can be multiple pools for the same collection, and you can create as many pools as you want. There is a small fee that must be paid when creating a pool.
 
-When creating a pool, you’ll be presented with some options:
+When creating a pool, you will be presented with the following options:
 
 * A pool with STARS (for buying NFTs)
-* A pool with NFTs (for selling NFTs)
+* A pool with NFTs (for selling)
 * A pool with both NFTs and STARS (for both buying and selling NFTs).
 
 <figure><img src="../../.gitbook/assets/image (4) (1) (1).png" alt=""><figcaption></figcaption></figure>
 
-You may then select the NFT collection you would like to pair with the STARS token.
+You can then select the NFT collection to pair with the STARS token.
 
-The last step is setting the pool parameters:
+The final step is to set the pool parameters:
 
 * The number of STARS tokens to deposit into the pool.
 * The specific NFTs from the selected collection that you would like to deposit into the pool.
-* The swap fee, which is the amount of tokens you will earn on every transaction (only applicable for “buy and sell” pools).
-* The bonding curve (linear / exponential / XYK). This is the algorithm used to determine pool prices.
+* The swap fee, which is the amount of STARS you will earn on every transaction (only applicable for 'buy and sell' pools).
+* The bonding curve (linear, exponential, or XYK). This is the algorithm used to determine pool prices.
 * The spot price, which is the starting pool price (only applicable for linear and exponential pools).
 * The delta, which is a parameter used to calculate subsequent pool prices (only applicable for linear and exponential pools).
 


### PR DESCRIPTION
During my review of the documentation, I identified a few areas where the phrasing could be improved for better readability and consistency. Here are the adjustments I made:

1. **"There can be multiple pools of the same collection, and you may create as many pools as you want."**
   - Improved number agreement:  
     **"There can be multiple pools for the same collection, and you can create as many pools as you want."**

2. **"When creating a pool, you’ll be presented with some options:"**
   - Reworded for clearer expression:  
     **"When creating a pool, you will be presented with the following options:"**

3. **"A pool with NFTs (for selling NFTs)"**
   - Removed redundancy for clarity:  
     **"A pool with NFTs (for selling)"**

4. **"You may then select the NFT collection you would like to pair with the STARS token."**
   - Reworded for smoother flow:  
     **"You can then select the NFT collection to pair with the STARS token."**

5. **"The last step is setting the pool parameters:"**
   - Slightly rephrased for a more natural tone:  
     **"The final step is to set the pool parameters:"**

6. **"The swap fee, which is the amount of tokens you will earn on every transaction (only applicable for “buy and sell” pools)."**
   - Changed "amount of tokens" to "amount of STARS" for accuracy:  
     **"The swap fee, which is the amount of STARS you will earn on every transaction (only applicable for 'buy and sell' pools)."**

7. **"The bonding curve (linear / exponential / XYK)."**
   - Replaced commas with "or" to improve readability:  
     **"The bonding curve (linear, exponential, or XYK)."**

These changes aim to enhance the clarity and precision of the documentation ;)